### PR TITLE
Feature/use icon constants in modulesidebar

### DIFF
--- a/frontend/src/components/modules-side-bar/ModulesSideBar.js
+++ b/frontend/src/components/modules-side-bar/ModulesSideBar.js
@@ -1,26 +1,12 @@
 import React, { Component } from 'react';
-// import Option from '../option/Option';
 import getIcons from '../../constants/icons.js';
 import { ListGroup, ListGroupItem} from 'reactstrap';
 
 class ModulesSideBar extends Component {
 
-  render(props) {
-    let icon;
-    //TODO the types are here defined, but they should come from slideTypes.js
-    //like import { VIDEO, PHOTOS, CODE, ANNOUNCEMENT } from './slideTypes.js';
+  render() {
+    const iconType = getIcons(this.props.data.type);
 
-    if(this.props.data.type.toLowerCase() === 'video'){
-      icon =( <i className="fa fa-youtube fa-3x"></i>)
-    } else if (this.props.data.type.toLowerCase() === 'photos'){
-      icon =( <i className="fa fa-camera-retro fa-3x"></i>)
-    } else if (this.props.data.type.toLowerCase() === 'code'){
-      icon =( <i className="fa fa-code fa-3x"></i>)
-    } else if (this.props.data.type.toLowerCase() === 'announcement'){
-      icon =( <i className="fa fa-calendar fa-3x"></i>)
-    } else if (this.props.data.type.toLowerCase() === 'repo'){
-      icon =( <i className="fa fa-github fa-3x"></i>)
-    }
     // the active indicator for the current sidebar module slide
     var classes = (this.props.current && this.props.current._id === this.props.data._id ) ? " slide-selected" : ""
     return (
@@ -28,7 +14,7 @@ class ModulesSideBar extends Component {
         <ListGroupItem className={ `type_${this.props.data.type.toLowerCase()} card p-3 mb-3 ${classes}`} onClick={(e)=>this.props.handleToggleClick(this)}>
           <div action className="d-flex flex-column flex-md-row align-items-center">
             <div className="mr-md-3">
-              {icon}
+              <i className={`fa fa-3x ${iconType}`}></i>
             </div>
             <div className="text ">
               <h4>{this.props.data.title}</h4>

--- a/frontend/src/constants/icons.js
+++ b/frontend/src/constants/icons.js
@@ -1,9 +1,10 @@
-import {VIDEO, PHOTOS, CODE, ANNOUNCEMENT} from './slideTypes.js';
+import {VIDEO, PHOTOS, CODE, ANNOUNCEMENT, REPO} from './slideTypes.js';
 
-const VIDEO_ICON = 'https://png.icons8.com/ios/50/000000/play-button-circled-filled.png';
-const PHOTOS_ICON = 'https://png.icons8.com/ios-glyphs/50/000000/picture.png';
-const CODE_ICON = 'https://png.icons8.com/ios/50/000000/code-file-filled.png';
-const ANNOUNCEMENT_ICON = 'https://png.icons8.com/ios-glyphs/50/000000/megaphone.png';
+const VIDEO_ICON = 'fa-youtube';
+const PHOTOS_ICON = 'fa-camera-retro';
+const CODE_ICON = 'fa-code';
+const ANNOUNCEMENT_ICON = 'fa-calendar';
+const REPO_ICON = 'fa-github';
 
 export default function getIcons(iconType) {
   switch (iconType) {
@@ -22,6 +23,10 @@ export default function getIcons(iconType) {
     case ANNOUNCEMENT:
       {
         return ANNOUNCEMENT_ICON;
+      }
+    case REPO:
+      {
+        return REPO_ICON;
       }
     default:
       console.log('Sorry, there are no icons');

--- a/frontend/src/constants/slideTypes.js
+++ b/frontend/src/constants/slideTypes.js
@@ -1,4 +1,5 @@
-export const VIDEO = 'VIDEO';
-export const PHOTOS = 'PHOTOS';
-export const CODE = 'CODE';
-export const ANNOUNCEMENT = 'ANNOUNCEMENT';
+export const VIDEO = 'video';
+export const PHOTOS = 'photos';
+export const CODE = 'code';
+export const ANNOUNCEMENT = 'announcement';
+export const REPO = 'repo';


### PR DESCRIPTION
- ModulesSidebar; Icons are now generated without if-else block;
- icons,js: add missing repo icon and changed icons from png links to font awesome strings
- slidetypes.js: converted everything to lowercase, as this is how they are used in the whole app and database