### PR TITLE
Feature/video progress bar not reflecting waiting until video ends

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,110 +1,116 @@
-import React, {Component} from 'react';
-import Photos from './components/photos/Photos.js';
-import './App.css';
-import Video from './components/video/Video.js';
-import Github from './components/github/Github.js';
-import ModulesSideBar from './components/modules-side-bar/ModulesSideBar';
-import SlideTimeline from './components/timeline/SlideTimeline.js';
-import SnippetSlide from './components/snippet-slide/SnippetSlide.js';
-import {Button, Nav, NavItem, NavLink} from 'reactstrap';
-import {PROGRESS_BAR_SPEED} from './constants/misc.js'
-import Announcement from './components/Announcement/Announcement';
+import React, { Component } from "react";
+import Photos from "./components/photos/Photos.js";
+import "./App.css";
+import Video from "./components/video/Video.js";
+import Github from "./components/github/Github.js";
+import ModulesSideBar from "./components/modules-side-bar/ModulesSideBar";
+import SlideTimeline from "./components/timeline/SlideTimeline.js";
+import SnippetSlide from "./components/snippet-slide/SnippetSlide.js";
+import { Button, Nav, NavItem, NavLink } from "reactstrap";
+import { PROGRESS_BAR_SPEED } from "./constants/misc.js";
+import Announcement from "./components/Announcement/Announcement";
 
-require('dotenv').config()
+require("dotenv").config();
 
 class App extends Component {
   state = {
     data: [],
-    youtubeCode: ['B7bqAsxee4I'],
+    youtubeCode: ["egfn6cPDQ6Q"],
     currentSlide: 0,
     playing: true,
-    duration: PROGRESS_BAR_SPEED
-  }
+    duration: PROGRESS_BAR_SPEED,
+    videoDuration: null
+  };
 
   componentDidMount() {
     //Read the configuration from /frontend/.env with fallback if not .env file created
     const domain = process.env.REACT_APP_DOMAIN || "http://localhost";
     const port = process.env.REACT_APP_BACKENDPORT || 4000;
-    fetch(`${domain}:${port}`).then(resp => resp.json()).then((data) => {
-      //get all data from the backend and sets the first slide active
-      this.setState({data: data, currentSlide: data[0]})
-      //sets a interval which holds all slides for XXXX milleseconds
-      this.timerID = setInterval(() => {
-        if (this.state.currentSlide.type.toLowerCase() !== 'video') {
-          if (this.state.playing) {
-            const key = this.findItemById(this.state.currentSlide)
-            this.autoSwitchSlide(key)
-          }
-        }
-      }, PROGRESS_BAR_SPEED * 1000);
-    })
+    fetch(`${domain}:${port}`)
+      .then(resp => resp.json())
+      .then(data => {
+        //get all data from the backend and sets the first slide active
+        this.setState({ data: data, currentSlide: data[0] });
+        //sets a interval which holds all slides for XXXX milleseconds
+        this.nextSlideInterval();
+      });
   }
 
   componentWillUnmount() {
     clearInterval(this.timerID);
   }
 
-  findItemById() {
-    let key = 0;
-    for (let i = 0; i < this.state.data.length; i++) {
-      if (this.state.data[i]._id === this.state.currentSlide._id) {
-        if (this.state.data.length > i) {
-          key = ++i;
-        }
+  nextSlideInterval = () => {
+    clearInterval(this.timerID);
+    if (this.state.currentSlide.type === "video") return;
+    this.timerID = setInterval(() => {
+      if (this.state.playing) {
+        const key = this.findItemById(this.state.currentSlide);
+        this.autoSwitchSlide(key);
       }
-    }
-    return key
+    }, this.state.duration * 1000);
+  };
+
+  setVideoDuration = duration => {
+    this.setState({ duration });
+  };
+
+  findItemById() {
+    return this.state.data.findIndex(item => item._id === this.state.currentSlide._id);
   }
 
   autoSwitchSlide(key) {
-    this.setState({duration: PROGRESS_BAR_SPEED})
-    if (this.state.data.length > key) {
-      this.setState({currentSlide: this.state.data[key]})
-    } else {
-      this.setState({currentSlide: this.state.data[0]})
-    }
+    this.setState({ duration: PROGRESS_BAR_SPEED });
+    // for the last slide set index back to zero
+    const slideIndex = this.state.data.length - 1 > key ? (key += 1) : 0;
+    this.setState({ currentSlide: this.state.data[slideIndex] });
+    this.nextSlideInterval();
   }
 
-  endingHandler = () => {
-    let key = this.findItemById(this.state.currentSlide)
-    this.autoSwitchSlide(key++)
-  }
+  videoEndingHandler = () => {
+    let key = this.findItemById(this.state.currentSlide);
+    this.autoSwitchSlide(key);
+  };
 
   slideHandler(slide) {
-    this.setState({currentSlide: slide.props.data, playing: false});
-    setTimeout(() => {
-      this.setState({playing: true})
-    }, PROGRESS_BAR_SPEED * 1000);
+    this.setState({ currentSlide: slide.props.data, playing: true });
+    this.nextSlideInterval();
+    // setTimeout(() => {
+    //   this.setState({ playing: true });
+    // }, PROGRESS_BAR_SPEED * 1000);
   }
 
-  sendInfo = (e) => {
-    e.preventDefault()
+  sendInfo = e => {
+    e.preventDefault();
     const form = {};
     for (let i = 0; i < e.target.elements.length; i++) {
       if (e.target.elements[i].value !== "") {
         form[e.target.elements[i].id] = e.target.elements[i].value;
       }
     }
-    this.setState({form: form});
-  }
+    this.setState({ form: form });
+  };
 
   render() {
     let content;
     if (this.state.currentSlide) {
       const slideType = this.state.currentSlide.type.toLowerCase();
       if (slideType === "video") {
-        content = <Video
-          youtubeCode={this.state.youtubeCode}
-          endingHandler={this.endingHandler}
+        content = (
+          <Video
+            youtubeCode={this.state.youtubeCode}
+            endingHandler={this.videoEndingHandler}
+            setVideoDuration={this.setVideoDuration}
           />
+        );
       } else if (slideType === "photos") {
-        content = <Photos data={this.state.currentSlide}/>
+        content = <Photos data={this.state.currentSlide} />;
       } else if (slideType === "repo") {
-        content = <Github data={this.state.currentSlide}/>
+        content = <Github data={this.state.currentSlide} />;
       } else if (slideType === "code") {
-        content = <SnippetSlide data={this.state.currentSlide}/>
+        content = <SnippetSlide data={this.state.currentSlide} />;
       } else if (slideType === "announcement") {
-        content = <Announcement data={this.state.currentSlide}/>
+        content = <Announcement data={this.state.currentSlide} />;
       }
     }
 
@@ -117,28 +123,30 @@ class App extends Component {
             </NavLink>
           </NavItem>
         </Nav>
-        <div className="skewed"></div>
+        <div className="skewed" />
         <div>
           <h1 id="title">DCI Digital Notice Board</h1>
         </div>
 
-        <div className='column1'>
-          {this.state.playing
-            ? <i className="fa fa-play">playing</i>
-            : <i className="fa fa-pause">pause</i>}
+        <div className="column1">
+          {this.state.playing ? (
+            <i className="fa fa-play">playing</i>
+          ) : (
+            <i className="fa fa-pause">pause</i>
+          )}
           {content}
-          <SlideTimeline time={PROGRESS_BAR_SPEED}/>
+          <SlideTimeline time={this.state.duration} />
         </div>
 
-        <div className='column2'>
+        <div className="column2">
           {this.state.data.map((item, value) => (
             <ModulesSideBar
               current={this.state.currentSlide}
               key={value}
               data={item}
               handleToggleClick={this.slideHandler.bind(this)}
-            />))
-          }
+            />
+          ))}
         </div>
       </div>
     );

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,7 +15,7 @@ require("dotenv").config();
 class App extends Component {
   state = {
     data: [],
-    youtubeCode: ["egfn6cPDQ6Q"],
+    youtubeCode: ["h9bk0m2TDaA"],
     currentSlide: 0,
     playing: true,
     duration: PROGRESS_BAR_SPEED,
@@ -42,6 +42,7 @@ class App extends Component {
 
   nextSlideInterval = () => {
     clearInterval(this.timerID);
+    // when slide is video, wait for videoEndinghandler instead
     if (this.state.currentSlide.type === "video") return;
     this.timerID = setInterval(() => {
       if (this.state.playing) {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,7 +19,6 @@ class App extends Component {
     currentSlide: 0,
     playing: true,
     duration: PROGRESS_BAR_SPEED,
-    videoDuration: null
   };
 
   componentDidMount() {

--- a/frontend/src/components/photos/Photos.css
+++ b/frontend/src/components/photos/Photos.css
@@ -28,7 +28,7 @@
 
 .progress {
 	border: 1px solid grey;
-	width: 857px;
+	width: 100%;
 	height: 10px;
 	margin: auto;
 	margin-bottom: 10px;

--- a/frontend/src/components/timeline/SlideTimeline.js
+++ b/frontend/src/components/timeline/SlideTimeline.js
@@ -1,49 +1,38 @@
-import React from 'react';
-import {Button} from 'reactstrap';
-import {Progress} from 'reactstrap';
+import React from "react";
+import { Progress } from "reactstrap";
+import "./SlideTimeline.css";
 
-import './SlideTimeline.css';
 class SlideTimeline extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      progress: 0,
-      time: props.time
-    }
-
-    this.progressTimer = this.progressTimer.bind(this);
+  state = {
+    progress: 0
   };
 
-  componentWillReceiveProps() {
-    clearInterval(this.interval)
-    this.interval = setInterval(this.progressTimer, this.calculateSeconds(this.state.time));
-    this.setState({progress: 0});
-
-  }
-  calculateSeconds(time) {
-    return (time / 100) * (1000)
-  }
-  componentDidMount() {
-    this.interval = setInterval(this.progressTimer, this.calculateSeconds(this.state.time));
+  componentWillReceiveProps(nextProps) {
+    clearInterval(this.interval);
+    this.setState({ progress: 0 });
+    this.interval = setInterval(this.progressTimer, this.convertSecondsToProgress(nextProps.time));
   }
 
-  progressTimer() {
-    this.setState(prevState => {
-      return {
-        progress: prevState.progress + 1
-      }
-    })
+  componentWillUnmount() {
+    clearInterval(this.interval);
   }
+
+  convertSecondsToProgress(time) {
+    return time * 1000 / 100;
+  }
+
+  progressTimer = () => {
+    this.setState(prevState => ({ progress: prevState.progress + 1 }));
+  };
 
   render() {
     if (this.state.progress >= 100) {
-      clearInterval(this.interval)
+      clearInterval(this.interval);
     }
     return (
       <div>
         <div className="text-center">{this.state.progress}%</div>
-        <Progress value={this.state.progress}/>
+        <Progress value={this.state.progress} />
       </div>
     );
   }

--- a/frontend/src/components/video/Video.js
+++ b/frontend/src/components/video/Video.js
@@ -1,14 +1,19 @@
-import React from 'react';
-import ReactPlayer from 'react-player';
-import './Video.css';
+import React from "react";
+import ReactPlayer from "react-player";
+import "./Video.css";
 
-const Video = (props) => {
-
+const Video = props => {
   return (
-	<div	className='slide-body'>
- <ReactPlayer width='100%' height='80vh'	onEnded={props.endingHandler} url={`https://www.youtube.com/embed/${props.youtubeCode}`} playing  />
-	</div>
- 
+    <div className="slide-body">
+      <ReactPlayer
+        width="100%"
+        height="80vh"
+        onDuration={duration => props.setVideoDuration(duration)}
+        onEnded={props.endingHandler}
+        url={`https://www.youtube.com/embed/${props.youtubeCode}`}
+        playing
+      />
+    </div>
   );
 };
 export default Video;


### PR DESCRIPTION
sorry for the many cosmetic changes. forgot I had "prettier" running on my home machine.
could probably reverse them by hand if they are too much to merge.

For the changes that matter: 
I have rewritten some of the logic behind the interval function and the duration parameters.
Videos now get their duration from the react-player.
On Autorun it now works pretty good, altough it is hard to get the bar perfect, because the load time of the video influences the total time. And the progressbar is a bit jumpy during loading time .. but it's only cosmetic.

Clicking on videos still messes with the interval in certain instances, but that was also broken before. So there should probably be a new ticket for that. 

Is clicking even needed when it's running on a Monitor in the floor? Is it a touch screen?