### PR TITLE
add method that updates state when a slide of the type is clicked

### DIFF
--- a/frontend/src/components/AddCode/AddCode.js
+++ b/frontend/src/components/AddCode/AddCode.js
@@ -1,37 +1,41 @@
-import React from 'react';
-import { Form, FormGroup, Label, Input, FormFeedback, FormText } from 'reactstrap';
+import React from "react";
+import { Form, FormGroup, Label, Input, FormFeedback, FormText } from "reactstrap";
 
 class AddCode extends React.Component {
   constructor(props) {
     super(props);
-    var props = this.props.data
-    props.displayDate = props.displayDate ? props.displayDate.slice(0, -14) : props.displayDate
-    props.expiryDate = props.expiryDate ? props.expiryDate.slice(0, -14) : props.expiryDate
+    var props = this.props.data;
+    props.displayDate = props.displayDate ? props.displayDate.slice(0, -14) : props.displayDate;
+    props.expiryDate = props.expiryDate ? props.expiryDate.slice(0, -14) : props.expiryDate;
     this.state = {
       form: this.props.data,
       fields: {},
       errors: {}
-    }
+    };
   }
+
+  // new lifecycle method. Called when receiving new props.
+  // here: updates state with formdata if new props are different from previous state
+  static getDerivedStateFromProps = (nextProps, prevState) => {
+    if (nextProps.data === prevState.data) return null;
+    else return { form: nextProps.data };
+  };
 
   //TODO optimize this validation and make it work for the other fields
   //https://waffle.io/devugees/digital-notice-board/cards/5ac2807897f9dd00256b555a
   onChange(field, value) {
-    let data = {...this.state.form};
-    data[field] = value
-    this.setState({form: data})
+    let data = { ...this.state.form };
+    data[field] = value;
+    this.setState({ form: data });
   }
 
   render() {
     return (
-      <Form onSubmit={(e) => this.props.sendChildInfo(e, this)}>
+      <Form onSubmit={e => this.props.sendChildInfo(e, this)}>
         <h1>{this.props.data._id ? "Edit Slide" : "Add Slide"}</h1>
         <FormGroup>
           <Label for="examplePassword">Title</Label>
-          <Input
-            id="title"
-            defaultValue={this.state.form.title}
-          />
+          <Input id="title" value={this.state.form.title} />
         </FormGroup>
         <FormGroup>
           <label>Description</label>
@@ -39,7 +43,7 @@ class AddCode extends React.Component {
             className="form-control"
             id="description"
             type="text"
-            defaultValue={this.state.form.description}
+            value={this.state.form.description}
           />
         </FormGroup>
         <FormGroup>
@@ -48,7 +52,7 @@ class AddCode extends React.Component {
             className="form-control"
             id="displayDate"
             type="date"
-            defaultValue={this.state.form.displayDate}
+            value={this.state.form.displayDate}
           />
         </FormGroup>
         <FormGroup>
@@ -57,21 +61,21 @@ class AddCode extends React.Component {
             className="form-control"
             id="expiryDate"
             type="date"
-            defaultValue={this.state.form.expiryDate}
+            value={this.state.form.expiryDate}
           />
         </FormGroup>
         <FormGroup>
           <Label>Code Snippet</Label>
-          <Input
-            id="content"
-            type="textarea"
-            defaultValue={this.state.form.content}
-          />
+          <Input id="content" type="textarea" value={this.state.form.content} />
         </FormGroup>
         <div className="d-flex justify-content-between">
-          <a className="text-muted" href="#">Delete this Slide</a>
-          <button type="submit" className="btn btn-primary">{this.props.data._id ? "Edit" : "Add"}</button>
-      </div>
+          <a className="text-muted" href="#">
+            Delete this Slide
+          </a>
+          <button type="submit" className="btn btn-primary">
+            {this.props.data._id ? "Edit" : "Add"}
+          </button>
+        </div>
       </Form>
     );
   }


### PR DESCRIPTION
content in AddCode on admin side is now updated even when you click on the same slide.
I only changed AddCode for now, because other students are still working on the other slidetypes and I don't want to cause merge conflicts for them.

The changes: 
- add method: static getDerivedStateFromProps that updates state on props change
- changed input "defaultValue" back to "value", otherwise it will not update. I think defaultValue is only used when it's first rendered, not on updates.

The rest is only some semicolons and indenting.

If the solution is ok for you, it can be easily added to the other slidetypes.